### PR TITLE
Block public access by default via PublicAccessBlockConfiguration - meet S3.8 rule reqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Serverless S3 Bucket Helper
 
-This plugin set settings on all S3 buckets. These are settings we want everywhere.
+This plugin sets settings on all S3 buckets. These are settings we generally want everywhere.
 
-Currently, it enables versioning.
+Currently,
+
+- versioning is enabled for all buckets, regardless of configuration... non-negotiable
+- public access is blocked via 'PublicAccessBlockConfiguration' by default.
 
 ## Usage
 
@@ -20,5 +23,5 @@ plugins:
 
 This plugin has two hooks:
 
-- package:createDeploymentArtifacts: This hook sets versioning on the sls deployment bucket.
-- package:compileEvents: This hook sets versioning on all other buckets.
+- package:createDeploymentArtifacts: This ensures the deployment bucket is configured correctly.
+- package:compileEvents: This hook ensures all buckets built by the service are configured correctly.

--- a/index.js
+++ b/index.js
@@ -1,36 +1,58 @@
 "use strict";
 
-const type = ["AWS::S3::Bucket"];
-const property = "VersioningConfiguration";
-const versioningConfiguration = {
-  Status: "Enabled",
-};
-
 class ServerlessPlugin {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
 
     this.hooks = {
-      // This will ensure versioning is enabled for the serverless deployment bucket.
-      "aws:deploy:deploy:createStack":
-        this.enableVersioningForBuckets.bind(this),
+      // This will ensure the serverless deployment bucket is configured correctly.
+      "aws:deploy:deploy:createStack": this.configureBuckets.bind(this),
 
-      // This will ensure versioning is enabled for all buckets.
-      "before:deploy:deploy": this.enableVersioningForBuckets.bind(this),
+      // This will configure all S3 buckets according to this plugin.
+      "before:deploy:deploy": this.configureBuckets.bind(this),
     };
   }
-  enableVersioningForBuckets() {
-    setPropertyForTypes.call(this, type, property, versioningConfiguration);
+  configureBuckets() {
+    // Forcibly enable versioning for all buckets.
+    setPropertyForTypes.call(
+      this,
+      ["AWS::S3::Bucket"],
+      "VersioningConfiguration",
+      {
+        Status: "Enabled",
+      },
+      true
+    );
+
+    // Block public access at the bucket level, unless explicitly set otherwise.  (SecurityHub S3.8)
+    setPropertyForTypes.call(
+      this,
+      ["AWS::S3::Bucket"],
+      "PublicAccessBlockConfiguration",
+      {
+        BlockPublicAcls: true,
+        BlockPublicPolicy: true,
+        IgnorePublicAcls: true,
+        RestrictPublicBuckets: true,
+      },
+      false
+    );
   }
 }
 
-function setPropertyForTypes(types, property, value) {
+function setPropertyForTypes(types, property, value, overrideExistingValue) {
   const template =
     this.serverless.service.provider.compiledCloudFormationTemplate;
   Object.keys(template.Resources).forEach(function (key) {
     if (types.includes(template.Resources[key]["Type"])) {
-      template.Resources[key]["Properties"][property] = value;
+      // Set the target property to the target value... if it's not already set OR we want to override any existing value.
+      if (
+        !(property in template.Resources[key]["Properties"]) ||
+        overrideExistingValue
+      ) {
+        template.Resources[key]["Properties"][property] = value;
+      }
     }
   });
 }


### PR DESCRIPTION
## Purpose

This changeset will block public access for all buckets unless explicitly overridden to allow it.  It is meant to enable consumers to meet Security Hub rule S3.8 "Block Public Access setting should be enabled at the bucket-level"

#### Linked Issues to Close

Closes #3 

## Approach

The approach taken is exactly as described in the approach section of #3:
- During two hooks in the serverless lifecycle, the plugin looks for S3::Bucket types in the in-memory cloudformation template.  This is not new.
- Any S3 bucket that is found is evaluated and potentially modified.  This is not new.
- If the bucket does not have a PublicAccessBlockConfiguration set, the plugin will add a PublicAccessBlockConfiguration property that sets all values to 'true', to block public access.
- If the bucket does have a PublicAccessBlockConfiguration already set, whether blocking public access or allowing it, the plugin does nothing.  This allows a consumer to create a bucket that must allow public access by design.

So, in short, by default, all buckets will block public access and meet the S3.8 rule requirements.

## Learning

N/A

## Assorted Notes/Considerations

Post merge, I'm going to manually cut a new release, 0.1.0.  This repo and the other plugin repos will need to get automated semantic versioning to be maintainable, however I'm going to operate it manually for the moment.  We knew when we cut these plugins to their individual repos that they wouldn't be fully automated projects yet, so I'm OK with it.

#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
