### PR TITLE
Fix bug that causes deployment buckets to be momentarily misconfigured

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,4 @@ plugins:
 
 ## Background
 
-This plugin has two hooks:
-
-- package:createDeploymentArtifacts: This ensures the deployment bucket is configured correctly.
-- package:compileEvents: This hook ensures all buckets built by the service are configured correctly.
+This plugin hooks into the serverless lifecycle at "before:deploy:deploy". There, it looks for S3 buckets and potentially modifies each. Currently, versioning is enabled for all buckets and public access is blocked by default.

--- a/index.js
+++ b/index.js
@@ -6,9 +6,6 @@ class ServerlessPlugin {
     this.options = options;
 
     this.hooks = {
-      // This will ensure the serverless deployment bucket is configured correctly.
-      "aws:deploy:deploy:createStack": this.configureBuckets.bind(this),
-
       // This will configure all S3 buckets according to this plugin.
       "before:deploy:deploy": this.configureBuckets.bind(this),
     };
@@ -42,18 +39,21 @@ class ServerlessPlugin {
 }
 
 function setPropertyForTypes(types, property, value, overrideExistingValue) {
-  const template =
-    this.serverless.service.provider.compiledCloudFormationTemplate;
-  Object.keys(template.Resources).forEach(function (key) {
-    if (types.includes(template.Resources[key]["Type"])) {
-      // Set the target property to the target value... if it's not already set OR we want to override any existing value.
-      if (
-        !(property in template.Resources[key]["Properties"]) ||
-        overrideExistingValue
-      ) {
-        template.Resources[key]["Properties"][property] = value;
+  [
+    this.serverless.service.provider.compiledCloudFormationTemplate,
+    this.serverless.service.provider.coreCloudFormationTemplate,
+  ].forEach(function (template) {
+    Object.keys(template.Resources).forEach(function (key) {
+      if (types.includes(template.Resources[key]["Type"])) {
+        // Set the target property to the target value... if it's not already set OR we want to override any existing value.
+        if (
+          !(property in template.Resources[key]["Properties"]) ||
+          overrideExistingValue
+        ) {
+          template.Resources[key]["Properties"][property] = value;
+        }
       }
-    }
+    });
   });
 }
 


### PR DESCRIPTION

## Purpose

This changeset fixes bug #5 which causes serverless deployment buckets to be briefly misconfigured when deploying a service for the very first time.

#### Linked Issues to Close

Closes #5 

## Approach

As mentioned in #5, the root cause here is an incomplete understanding of serverless' inner workings.

There are two cloudformation template objects that are used during deployment:  coreCloudFormationTemplate and compiledCloudFormationTemplate.  Each are generated on deployment, regardless if its a new service being deployed for the first time or an existing service being redeployed.  However, the coreCloudFormationTemplate is what's responsible for creating the cloudformation stack and deployment bucket on a absolutely new deploy.  Currently (without this changeset), the plugin is only concerned / only modifies the compiledCloudFormationTemplate.  So, on a clean deploy, the serverless deployment bucket, as defined in the core template, does not get versioning and public access blocking enforced.  This changeset fixes that.

This plugin now hooks into just the "before:deploy:deploy" lifecycle event, and searches and potentially modifies both the core and compiled templates.  The logic is unchanged in this PR and is the same for both templates:
- look for any/all S3 buckets in the template
- ensure versioning is enabled for each bucket
- set public access blocking by default (so do nothing if its already set on a bucket)


## Learning

The learning stage was a hands on affair.  It was clear that the plugin was working as intended, except for brand new services that had their stack created but never deployed.  Some poking around the serverless.provider object led to the discovery of the coreCloudFormationTemplate; modifying that worked.

## Assorted Notes/Considerations

- Non breaking change...  Tick the patch version.

#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
