### PR TITLE
Support setting up Logging Configuration for all buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Currently,
 ## Usage
 
 ```yaml
-
 plugins:
   - serverless-s3-bucket-helper
 

--- a/README.md
+++ b/README.md
@@ -6,19 +6,22 @@ Currently,
 
 - versioning is enabled for all buckets, regardless of configuration... non-negotiable
 - public access is blocked via 'PublicAccessBlockConfiguration' by default.
+- optionally, enable s3 server access logging for all buckets
 
 ## Usage
 
-```
-...
+```yaml
 
 plugins:
   - serverless-s3-bucket-helper
 
-...
-
+s3BucketHelper:
+  # Optional setting for enabling s3 server access logging.
+  loggingConfiguration:
+    destinationBucketName: my-logging-bucket
+    logFilePrefix: path/for/logs
 ```
 
 ## Background
 
-This plugin hooks into the serverless lifecycle at "before:deploy:deploy". There, it looks for S3 buckets and potentially modifies each. Currently, versioning is enabled for all buckets and public access is blocked by default.
+This plugin hooks into the serverless lifecycle at "before:deploy:deploy". There, it looks for S3 buckets and potentially modifies each. Currently, versioning is enabled for all buckets and public access is blocked by default. Enabling S3 server access logging requires setting the optional `loggingConfiguration` for the top level `s3BucketHelper` property.

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ class ServerlessPlugin {
   }
 
   getPluginConfig() {
-    return this.serverless.service.s3BucketHelper;
+    return this.serverless.configurationInput.s3BucketHelper;
   }
 
   getLoggingConfiguration() {


### PR DESCRIPTION
## Purpose

[[S3.9] S3 bucket server access logging should be enabled](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-s3-9) suggest enabling Server Access Logging for all buckets, which can be done via setting up the LoggingConfiguration of the S3 Bucket resource. It would be helpful to add support to the helper plugin to cover the deployment buckets themselves and resolve the S3.9 findings we are seeing in some of our accounts.

#### Linked Issues to Close

None

## Approach

Added a top level property for the plugin and allow specifying optional properties for the target logging bucket and prefix to use for the S3 logs. These properties are optional and are not required to be set unless you need access logging enabled.

## Learning

[[S3.9] S3 bucket server access logging should be enabled](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-s3-9) 

## Assorted Notes/Considerations

This was tested using the MCR repo at https://github.com/CMSgov/mdct-mcr/pull/2320

#### Pull Request Creator Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [ ] Someone has been assigned this PR.
- [ ] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
